### PR TITLE
Handle JSON parse errors as page load failures

### DIFF
--- a/SGAPI/ItemSets/SGItemSet.m
+++ b/SGAPI/ItemSets/SGItemSet.m
@@ -178,6 +178,9 @@
 #pragma mark - Getters
 
 - (BOOL)lastPageAlreadyFetched {
+    if (self.items && self.items.count == 0) {
+        return YES;
+    }
     if (!self.meta) {
         return NO;
     }

--- a/SGAPI/ItemSets/SGItemSet.m
+++ b/SGAPI/ItemSets/SGItemSet.m
@@ -89,7 +89,16 @@
 - (void)processResults:(NSData *)data {
     __weakSelf me = self;
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        NSDictionary *dict = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+        NSError *error = nil;
+        NSDictionary *dict = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
+        if (error) {
+            if (me.onPageLoadFailed) {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    me.onPageLoadFailed(error);
+                });
+            }
+            return;
+        }
         NSArray *results = dict[me.resultArrayKey];
 
         NSMutableOrderedSet *newItems = NSMutableOrderedSet.orderedSet;


### PR DESCRIPTION
Maybe this eventually warrants a different error handler, but this is better than pretending everything succeeded, since that might trigger an infinite loop in library clients.
