### PR TITLE
 Refactor SGQuery creation to keep baseURL internal

### DIFF
--- a/SGAPI/SGQuery.h
+++ b/SGAPI/SGQuery.h
@@ -204,8 +204,10 @@ Add a results filter. Filters are stacked, and the same filters can be applied m
 @property (nonatomic, strong) NSDictionary *requestHeaders;
 
 // ignore plz
+// note: these constructors truncate query params!
 + (SGQuery *)queryWithPath:(NSString *)path;
-+ (SGQuery *)queryWithSchemeHostPath:(NSString *)schemeHostPath;  // truncates query params!
++ (SGQuery *)queryWithBaseUrl:(NSString *)baseUrl;
++ (SGQuery *)queryWithBaseUrl:(NSString *)baseUrl path:(NSString *)path;
 + (NSMutableDictionary *)globalParameters;
 + (void)setBaseURL:(NSString *)url;
 

--- a/SGAPI/SGQuery.h
+++ b/SGAPI/SGQuery.h
@@ -204,9 +204,9 @@ Add a results filter. Filters are stacked, and the same filters can be applied m
 @property (nonatomic, strong) NSDictionary *requestHeaders;
 
 // ignore plz
-+ (SGQuery *)queryWithString:(NSString *)string;
++ (SGQuery *)queryWithPath:(NSString *)path;
++ (SGQuery *)queryWithSchemeHostPath:(NSString *)schemeHostPath;  // truncates query params!
 + (NSMutableDictionary *)globalParameters;
 + (void)setBaseURL:(NSString *)url;
-+ (NSString *)baseURL;
 
 @end

--- a/SGAPI/SGQuery.m
+++ b/SGAPI/SGQuery.m
@@ -11,7 +11,7 @@ BOOL _gConsoleLogging;
 NSMutableDictionary *_globalParams;
 
 @interface SGQuery ()
-@property (nonatomic, strong) NSString *schemeHostPath;
+@property (nonatomic, strong) NSString *baseUrl;
 @property (nonatomic, strong) NSString *path;
 @property (nonatomic, strong) NSString *query;
 @property (nonatomic, strong) NSMutableDictionary *parameters;
@@ -25,19 +25,16 @@ NSMutableDictionary *_globalParams;
 }
 
 + (SGQuery *)queryWithPath:(NSString *)path {
-    return [SGQuery queryWithPath:path orSchemeHostPath:nil];
+    return [SGQuery queryWithBaseUrl:nil path:path];
 }
 
-+ (SGQuery *)queryWithSchemeHostPath:(NSString *)schemeHostPath {
-    return [SGQuery queryWithPath:nil  orSchemeHostPath:schemeHostPath];
++ (SGQuery *)queryWithBaseUrl:(NSString *)baseUrl {
+    return [SGQuery queryWithBaseUrl:baseUrl path:nil];
 }
 
-+ (SGQuery *)queryWithPath:(NSString *)path orSchemeHostPath:(NSString *)schemeHostPath  {
-    if (path && schemeHostPath) {
-        return nil;
-    }
++ (SGQuery *)queryWithBaseUrl:(NSString *)baseUrl path:(NSString *)path {
     SGQuery *query = self.new;
-    query.schemeHostPath = schemeHostPath;
+    query.baseUrl = baseUrl;
     query.path = path;
     [query rebuildQuery];
     return query;
@@ -210,11 +207,10 @@ NSMutableDictionary *_globalParams;
 #pragma mark - Getters
 
 - (NSURL *)URL {
-    NSString *schemeHostPath = self.schemeHostPath;
-    if (self.path) {
-        schemeHostPath = [NSString stringWithFormat:@"%@%@", _gBaseURL, self.path];
-    }
-    NSURLComponents *bits = [NSURLComponents componentsWithString:schemeHostPath];
+    NSString *baseUrl = self.baseUrl ?: _gBaseURL;
+    NSString *path = self.path ?: @"";
+    NSString *url = [baseUrl stringByAppendingString:path];
+    NSURLComponents *bits = [NSURLComponents componentsWithString:url];
     bits.query = self.query;
     return bits.URL;
 }

--- a/SGAPI/SGQuery.m
+++ b/SGAPI/SGQuery.m
@@ -11,7 +11,9 @@ BOOL _gConsoleLogging;
 NSMutableDictionary *_globalParams;
 
 @interface SGQuery ()
-@property (nonatomic, strong) NSURLComponents *bits;
+@property (nonatomic, strong) NSString *schemeHostPath;
+@property (nonatomic, strong) NSString *path;
+@property (nonatomic, strong) NSString *query;
 @property (nonatomic, strong) NSMutableDictionary *parameters;
 @property (nonatomic, copy) NSString *filters;
 @end
@@ -22,9 +24,21 @@ NSMutableDictionary *_globalParams;
     self.baseURL = SGAPI_BASEURL;
 }
 
-+ (SGQuery *)queryWithString:(NSString *)string {
++ (SGQuery *)queryWithPath:(NSString *)path {
+    return [SGQuery queryWithPath:path orSchemeHostPath:nil];
+}
+
++ (SGQuery *)queryWithSchemeHostPath:(NSString *)schemeHostPath {
+    return [SGQuery queryWithPath:nil  orSchemeHostPath:schemeHostPath];
+}
+
++ (SGQuery *)queryWithPath:(NSString *)path orSchemeHostPath:(NSString *)schemeHostPath  {
+    if (path && schemeHostPath) {
+        return nil;
+    }
     SGQuery *query = self.new;
-    query.bits = [NSURLComponents componentsWithString:string];
+    query.schemeHostPath = schemeHostPath;
+    query.path = path;
     [query rebuildQuery];
     return query;
 }
@@ -32,27 +46,27 @@ NSMutableDictionary *_globalParams;
 #pragma mark - Events Query Factories
 
 + (SGQuery *)eventsQuery {
-    return [self queryWithString:[NSString stringWithFormat:@"%@/events", SGQuery.baseURL]];
+    return [self queryWithPath:@"/events"];
 }
 
 + (SGQuery *)recommendationsQuery {
-    return [self queryWithString:[NSString stringWithFormat:@"%@/recommendations", SGQuery.baseURL]];
+    return [self queryWithPath:@"/recommendations"];
 }
 
 + (SGQuery *)eventQueryForId:(NSNumber *)eventId {
-    id url = [NSString stringWithFormat:@"%@/events/%@", SGQuery.baseURL, eventId];
-    return [self queryWithString:url];
+    id path = [NSString stringWithFormat:@"/events/%@", eventId];
+    return [self queryWithPath:path];
 }
 
 #pragma mark - Performers Query Factories
 
 + (SGQuery *)performersQuery {
-    return [self queryWithString:[NSString stringWithFormat:@"%@/performers", SGQuery.baseURL]];
+    return [self queryWithPath:@"/performers"];
 }
 
 + (SGQuery *)performerQueryForId:(NSNumber *)performerId {
-    id url = [NSString stringWithFormat:@"%@/performers/%@", SGQuery.baseURL, performerId];
-    return [self queryWithString:url];
+    id path = [NSString stringWithFormat:@"/performers/%@", performerId];
+    return [self queryWithPath:path];
 }
 
 + (SGQuery *)performerQueryForSlug:(NSString *)slug {
@@ -64,12 +78,12 @@ NSMutableDictionary *_globalParams;
 #pragma mark - Venues Query Factories
 
 + (SGQuery *)venuesQuery {
-    return [self queryWithString:[NSString stringWithFormat:@"%@/venues", SGQuery.baseURL]];
+    return [self queryWithPath:@"/venues"];
 }
 
 + (SGQuery *)venueQueryForId:(NSNumber *)venueId {
-    id url = [NSString stringWithFormat:@"%@/venues/%@", SGQuery.baseURL, venueId];
-    return [self queryWithString:url];
+    id path = [NSString stringWithFormat:@"/venues/%@", venueId];
+    return [self queryWithPath:path];
 }
 
 #pragma mark - Query Rebuilding
@@ -97,7 +111,7 @@ NSMutableDictionary *_globalParams;
 }
 
 - (void)rebuildQuery {
-    self.bits.query = nil;
+    self.query = nil;
     for (id param in self.class.globalParameters) {
         [self addParameterToQuery:param value:self.class.globalParameters[param]];
     }
@@ -105,21 +119,21 @@ NSMutableDictionary *_globalParams;
         [self addParameterToQuery:param value:self.parameters[param]];
     }
     if (self.filters.length) {
-        if (self.bits.query.length) {
+        if (self.query.length) {
             NSString *appendage = [NSString stringWithFormat:@"&%@", self.filters];
-            self.bits.query = [self.bits.query stringByAppendingString:appendage];
+            self.query = [self.query stringByAppendingString:appendage];
         } else {
-            self.bits.query = [self.bits.query stringByAppendingString:self.filters];
+            self.query = [self.query stringByAppendingString:self.filters];
         }
     }
 }
 
 - (void)addParameterToQuery:(NSString *)param value:(id)value {
-    if (self.bits.query.length) {
+    if (self.query.length) {
         NSString *appendage = [NSString stringWithFormat:@"&%@=%@", param, value];
-        self.bits.query = [self.bits.query stringByAppendingString:appendage];
+        self.query = [self.query stringByAppendingString:appendage];
     } else {
-        self.bits.query = [NSString stringWithFormat:@"%@=%@", param, value];
+        self.query = [NSString stringWithFormat:@"%@=%@", param, value];
     }
 }
 
@@ -195,12 +209,14 @@ NSMutableDictionary *_globalParams;
 
 #pragma mark - Getters
 
-+ (NSString *)baseURL {
-    return _gBaseURL;
-}
-
 - (NSURL *)URL {
-    return self.bits.URL;
+    NSString *schemeHostPath = self.schemeHostPath;
+    if (self.path) {
+        schemeHostPath = [NSString stringWithFormat:@"%@%@", _gBaseURL, self.path];
+    }
+    NSURLComponents *bits = [NSURLComponents componentsWithString:schemeHostPath];
+    bits.query = self.query;
+    return bits.URL;
 }
 
 - (SGHTTPRequest *)requestWithMethod:(SGHTTPRequestMethod)method {


### PR DESCRIPTION
This creates a simpler SGQuery constructor that only needs the URL path and not the API's baseUrl. For these queries, the baseURL is used to construct the full URL only at the time the request is created. This allows the baseURL to be changed (perhaps between debug URLs) without requiring the SGQuery objects be recreated. URLs on other hosts can still be queried as before, but using a different constructor.

Also note that paths should have a leading "/" in most cases. This makes it easier to search the codebase for a specific endpoint, i.e. "/events" returns many fewer results than "event".
