### PR TITLE
Return `nil` in factory method if URL is invalid

### DIFF
--- a/SGAPI/SGQuery.m
+++ b/SGAPI/SGQuery.m
@@ -42,11 +42,8 @@ NSMutableDictionary *_globalParams;
     SGQuery *query = self.new;
     query.baseUrl = baseUrl;
     query.path = path;
-    if (query.URL) {
-        [query rebuildQuery];
-        return query;
-    }
-    return nil;
+    [query rebuildQuery];
+    return query;
 }
 
 #pragma mark - Events Query Factories
@@ -141,6 +138,9 @@ NSMutableDictionary *_globalParams;
 
 - (void)rebuildQuery {
     self.query = nil;
+    if (!self.URL) {
+        return;
+    }
 
     NSURLComponents *components = [NSURLComponents componentsWithURL:self.URL resolvingAgainstBaseURL:NO];
     NSMutableArray *queryItems = NSMutableArray.array;

--- a/SGAPI/SGQuery.m
+++ b/SGAPI/SGQuery.m
@@ -42,8 +42,11 @@ NSMutableDictionary *_globalParams;
     SGQuery *query = self.new;
     query.baseUrl = baseUrl;
     query.path = path;
-    [query rebuildQuery];
-    return query;
+    if (query.URL) {
+        [query rebuildQuery];
+        return query;
+    }
+    return nil;
 }
 
 #pragma mark - Events Query Factories


### PR DESCRIPTION
Otherwise, `rebuildQuery` will send `nil` for the URL when trying to make the `NSURLComponents` on [line 142](https://github.com/seatgeek/SGAPI/blob/8c7eefb30d55f339257b5ccc8af48194d0ebe934/SGAPI/SGQuery.m#L142), causing it to crash.  This happens because, in the getter for the `URL` property on [line 260](https://github.com/seatgeek/SGAPI/blob/8c7eefb30d55f339257b5ccc8af48194d0ebe934/SGAPI/SGQuery.m#L260), `bits` will be `nil` if the `url` is invalid.

This is easy to repro by invoking the factory method with a `path` that has a space or other [unsafe character](http://stackoverflow.com/a/497972/551814).