### PR TITLE
Split the base API URL into a domain and format

### DIFF
--- a/SGAPI/SGQuery.h
+++ b/SGAPI/SGQuery.h
@@ -5,7 +5,8 @@
 #import <CoreLocation/CoreLocation.h>
 #import <SGHTTPRequest/SGHTTPRequest.h>
 
-#define SGAPI_BASEURL @"https://api.seatgeek.com/2"
+#define SGAPI_BASEFORMAT @"https://api.%@/2"
+#define SGAPI_BASEDOMAIN @"seatgeek.com"
 
 #ifndef __weakSelf
 #define __weakSelf __weak typeof(self)
@@ -231,6 +232,7 @@ Add a results filter. Filters are stacked, and the same filters can be applied m
 + (SGQuery *)queryWithBaseUrl:(NSString *)baseUrl;
 + (SGQuery *)queryWithBaseUrl:(NSString *)baseUrl path:(NSString *)path;
 + (NSMutableDictionary *)globalParameters;
++ (NSString *)defaultBaseDomain;
 + (NSString *)baseURL;
 + (void)setBaseURL:(NSString *)url;
 - (void)setPath:(NSString *)path;

--- a/SGAPI/SGQuery.m
+++ b/SGAPI/SGQuery.m
@@ -22,11 +22,11 @@ NSMutableDictionary *_globalParams;
 @implementation SGQuery
 
 + (void)initialize {
-    self.baseURL = self.defaultBaseURL;
+    self.baseURL = [NSString stringWithFormat:SGAPI_BASEFORMAT, self.defaultBaseDomain];
 }
 
-+ (NSString *)defaultBaseURL {
-    return SGAPI_BASEURL;
++ (NSString *)defaultBaseDomain {
+    return SGAPI_BASEDOMAIN;
 }
 
 + (SGQuery *)queryWithPath:(NSString *)path {


### PR DESCRIPTION
This will make it easier for us internally to change request domains for use with a staging environment.