### PR TITLE
Move recursive deep fetch from SGDataManager to SGItem

### DIFF
--- a/SGAPI/Items/SGItem.h
+++ b/SGAPI/Items/SGItem.h
@@ -62,6 +62,13 @@
 - (void)fetch;
 
 /**
+ * Calls `fetch` on the item and recursively on all of its child items.
+ * If one of these items is already <fetching> or does not <needsRefresh>,
+ * then its `fetch` will do nothing.
+ */
+- (void)fetchItemAndChildrenIfNeeded;
+
+/**
 * Returns YES if a fetch is in progress.
 */
 - (BOOL)fetching;

--- a/SGAPI/Items/SGItem.m
+++ b/SGAPI/Items/SGItem.m
@@ -47,6 +47,15 @@ static NSDateFormatter *_formatterLocal, *_formatterUTC;
 
 #pragma mark - Fetching and caching
 
+- (void)fetchItemAndChildrenIfNeeded {
+    if (self.needsRefresh && !self.fetching) {
+        [self fetch];
+    }
+    for (SGItem *child in self.childItems) {
+        [child fetchItemAndChildrenIfNeeded];
+    }
+}
+
 - (void)fetch {
     if (self.fetching) {
         return;

--- a/SGAPI/SGDataManager.m
+++ b/SGAPI/SGDataManager.m
@@ -38,19 +38,7 @@
 
     // need to refresh any individual items?
     for (SGItem *item in self.itemSet.orderedSet) {
-        if (item.needsRefresh && !item.fetching) {
-            [item fetch];
-        }
-        [self fetchChildrenOf:item];
-    }
-}
-
-- (void)fetchChildrenOf:(SGItem *)item {
-    for (SGItem *child in item.childItems) {
-        if (child.needsRefresh && !child.fetching) {
-            [child fetch];
-        }
-        [self fetchChildrenOf:child];
+        [item fetchItemAndChildrenIfNeeded];
     }
 }
 


### PR DESCRIPTION
This method was not specific to the data manager in question, and I needed to expose it for use outside of the data manage in our app. Note that simply overriding fetch to also fetch the children would not work, becuase it is a common pattern for subclasses of SGItem to override fetch without calling super.