### PR TITLE
remove `images` property from SGPerformer

### DIFF
--- a/SGAPI.podspec
+++ b/SGAPI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "SGAPI"
-  s.version      = "1.4.0"
+  s.version      = "1.5.0"
   s.summary      = "An iOS SDK for querying the SeatGeek Platform web service."
   s.homepage     = "http://platform.seatgeek.com"
   s.license      = { :type => "BSD", :file => "LICENSE" }

--- a/SGAPI/Items/SGPerformer.h
+++ b/SGAPI/Items/SGPerformer.h
@@ -50,11 +50,6 @@ Either the same as <name> or a shortened name if one is available.
 @property (nonatomic, readonly, copy) NSString *imageURL;
 
 /**
-* URLs for images of the performer at varying sizes.
-*/
-@property (nonatomic, readonly, strong) NSDictionary *images;
-
-/**
 * Links to the performer on other services across the web.
 */
 @property (nonatomic, readonly, strong) NSArray *links;

--- a/SGAPI/Items/SGPerformer.m
+++ b/SGAPI/Items/SGPerformer.m
@@ -18,7 +18,6 @@
             @"imageURL":@"image",
             @"stats":@"stats",
             @"taxonomies":@"taxonomies",
-            @"images":@"images",
             @"links":@"links",
             @"homeVenueId":@"home_venue_id",
             @"hasUpcomingEvents":@"has_upcoming_events"


### PR DESCRIPTION
issue: https://github.com/seatgeek/iphone-app/issues/8069, https://github.com/seatgeek/iphone-app/issues/8068

Our API is moving towards deprecating the use of the images array


